### PR TITLE
Stream Deck Store release should have logging disabled

### DIFF
--- a/cmd/hwinfo_streamdeck_plugin/main.go
+++ b/cmd/hwinfo_streamdeck_plugin/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
 
 	// "net/http"
@@ -28,24 +29,31 @@ func main() {
 		log.Fatalf("Unable to chdir: %v", err)
 	}
 
-	appdata := os.Getenv("APPDATA")
-	logpath := filepath.Join(appdata, "Elgato/StreamDeck/Plugins/com.exension.hwinfo.sdPlugin/hwinfo.log")
-	f, err := os.OpenFile(logpath, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		log.Fatalf("OpenFile Log: %v", err)
-	}
-	err = f.Truncate(0)
-	if err != nil {
-		log.Fatalf("Truncate Log: %v", err)
-	}
-	defer func() {
-		err := f.Close()
-		if err != nil {
-			log.Fatalf("File Close: %v", err)
-		}
-	}()
-	log.SetOutput(f)
-	log.SetFlags(0)
+	// PRODUCTION
+	// LOGGING DISABLED:
+	//
+	log.SetOutput(ioutil.Discard)
+
+	// DEBUG LOGGING:
+	//
+	// appdata := os.Getenv("APPDATA")
+	// logpath := filepath.Join(appdata, "Elgato/StreamDeck/Plugins/com.exension.hwinfo.sdPlugin/hwinfo.log")
+	// f, err := os.OpenFile(logpath, os.O_RDWR|os.O_CREATE, 0666)
+	// if err != nil {
+	// 	log.Fatalf("OpenFile Log: %v", err)
+	// }
+	// err = f.Truncate(0)
+	// if err != nil {
+	// 	log.Fatalf("Truncate Log: %v", err)
+	// }
+	// defer func() {
+	// 	err := f.Close()
+	// 	if err != nil {
+	// 		log.Fatalf("File Close: %v", err)
+	// 	}
+	// }()
+	// log.SetOutput(f)
+	// log.SetFlags(0)
 
 	flag.Parse()
 

--- a/com.exension.hwinfo.sdPlugin/manifest.json
+++ b/com.exension.hwinfo.sdPlugin/manifest.json
@@ -28,12 +28,9 @@
   "Name": "HWiNFO",
   "Icon": "pluginIcon",
   "URL": "https://github.com/exension/hwinfo-streamdeck",
-  "Version": "2.0.2",
+  "Version": "2.0.3",
   "ApplicationsToMonitor": {
-    "windows": [
-      "HWiNFO64.EXE",
-      "HWiNFO64.exe"
-    ]
+    "windows": ["HWiNFO64.EXE", "HWiNFO64.exe"]
   },
   "OS": [
     {


### PR DESCRIPTION
There seems to be some hard coded debugging output when there is anomalies due to missing sensors or hwinfo communication.

We have a test machine with a small entry level flash storage that managed to get killed(not really dead but super saturated so it become extremely slow) due to the massive numbers of tiny writes, when the sensor are not found. And so far we traced it to the hwinfo.log file which hwinfo.exe is constantly writing to it.

This is a test machine so basically it was left running for a long time without people noticing, so this should not happen on normal users. But for people with other use cases which they need to tentatively remove or turning off some equipment sometimes, do remember that the hwinfo.exe will starts chugging out errors writes.