### PR TITLE
Fix handle leak

### DIFF
--- a/internal/hwinfo/shmem/shmem.go
+++ b/internal/hwinfo/shmem/shmem.go
@@ -59,6 +59,7 @@ func ReadBytes() ([]byte, error) {
 		return nil, err
 	}
 	defer unmapViewOfFile(addr)
+	defer windows.CloseHandle(windows.Handle(hnd))
 
 	return copyBytes(addr), nil
 }


### PR DESCRIPTION
`ReadBytes` is called every second causing handles to [`HWiNFO_SENSORS_MAP_FILE_NAME2`](https://github.com/shayne/hwinfo-streamdeck/blob/52c32d4/internal/hwinfo/hwisenssm2.h#L5) to pile up