### PR TITLE
Move the toolchain to go1.26.6 for the August stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/moeilijk/hwinfo-streamdeck
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0


### PR DESCRIPTION
Four Go stdlib advisories landed on 13-08-2026 (GO-2026-6089 net/http, GO-2026-6090 crypto/tls, GO-2026-6091 html/template, GO-2026-5972 encoding/asn1), all fixed in go1.26.6. `govulncheck` resolves a fresh database on every run, so the pinned go1.26.5 toolchain broke PR #106 the day after publication and would take `main` down on the Monday cron.

The only reachable trace was `cmd/mock-bridge/main.go:351` → `plugin.Serve` → `asn1.Unmarshal`.

Verified locally with the workflow's own invocation (`CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 govulncheck ./...`): **0 vulnerabilities**.